### PR TITLE
modify sf table name case problem

### DIFF
--- a/src/main/scala/com/tigergraph/spark_connector/reader/Reader.scala
+++ b/src/main/scala/com/tigergraph/spark_connector/reader/Reader.scala
@@ -20,6 +20,10 @@ trait Reader {
 
   def reader(spark: SparkSession): DataFrameReader
 
+  def getPassword(): String
+
+  def setPassword(password: String)
+
   def getTables(): ArrayBuffer[String]
 
   def readTable(df: DataFrameReader, table: String): DataFrame

--- a/src/main/scala/com/tigergraph/spark_connector/support/SnowFlakeSupport.scala
+++ b/src/main/scala/com/tigergraph/spark_connector/support/SnowFlakeSupport.scala
@@ -22,8 +22,17 @@ class SnowFlakeSupport(val supportName: String, val path: String) extends Suppor
   }
 
   def getTableInfo(table: String): (String, String) = {
-    val sf2TigerKV = config.get("mappingRules")
-      .asInstanceOf[util.HashMap[String, Object]].get(table).asInstanceOf[util.HashMap[String, Object]]
+    val tgMapping: util.HashMap[String, Object] = config.get("mappingRules")
+      .asInstanceOf[util.HashMap[String, Object]]
+
+    import scala.collection.JavaConversions._
+
+    var tgMap = new util.HashMap[String, Object]()
+    for (key <- tgMapping.keySet()) {
+      tgMap.put(key.toUpperCase, tgMapping.get(key))
+    }
+
+    val sf2TigerKV = tgMap.get(table).asInstanceOf[util.HashMap[String, Object]]
 
     val jobName = sf2TigerKV.get("dbtable").toString
 
@@ -33,8 +42,17 @@ class SnowFlakeSupport(val supportName: String, val path: String) extends Suppor
   }
 
   def getLoadingJobInfo(table: String): util.HashMap[String, String] = {
-    val sf2TigerKV = config.get("mappingRules")
-      .asInstanceOf[util.HashMap[String, Object]].get(table).asInstanceOf[util.HashMap[String, Object]]
+    val tgMapping: util.HashMap[String, Object] = config.get("mappingRules")
+      .asInstanceOf[util.HashMap[String, Object]]
+
+    import scala.collection.JavaConversions._
+
+    var tgMap = new util.HashMap[String, Object]()
+    for (key <- tgMapping.keySet()) {
+      tgMap.put(key.toUpperCase, tgMapping.get(key))
+    }
+
+    val sf2TigerKV = tgMap.get(table).asInstanceOf[util.HashMap[String, Object]]
 
     val tigerMap = sf2TigerKV.get("jobConfig").asInstanceOf[util.HashMap[String, Object]]
     val filename = tigerMap.get("filename").asInstanceOf[String]


### PR DESCRIPTION
Fixed the following issues:
1. Fix sf table name case problem. Before the repair, the case of the snowflake table in the yaml file must be the same as the key value of the loading job. After optimization, the case is irrelevant
2. Optimized the problem of blocking the input of the sf password.  Before optimization, no matter whether the password is configured or not, you must manually enter the password to continue running. After optimization, if it is configured, the program will not be blocked.